### PR TITLE
Cbor persist

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="1.7.21" />
+    <option name="version" value="1.8.20-RC" />
   </component>
 </project>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 plugins {
     kotlin("jvm") version "1.7.21"
     application
+    id("org.jetbrains.kotlin.plugin.serialization") version "1.8.20-RC"
 }
 
 group = "ie.setu"
@@ -24,6 +25,9 @@ dependencies {
     //For Streaming to XML and JSON
     implementation("com.thoughtworks.xstream:xstream:1.4.18")
     implementation("org.codehaus.jettison:jettison:1.4.1")
+
+    // CBOR Gradle
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-cbor:1.5.0")
 
 }
 tasks.test {

--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -1,22 +1,24 @@
 import controllers.NoteAPI
 import models.Note
 import mu.KotlinLogging
+import persistence.CBORSerializer
 import persistence.JSONSerializer
-import persistence.XMLSerializer
 import utils.ScannerInput
 import utils.ScannerInput.readNextInt
 import utils.ScannerInput.readNextLine
 import java.io.File
 import java.lang.System.exit
-import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
-import java.util.*
 
 private val logger = KotlinLogging.logger {}
 
+
+// Persistence formats
 //private val noteAPI = NoteAPI(XMLSerializer(File("notes.xml")))
-private val noteAPI = NoteAPI(JSONSerializer(File("notes.json")))
+//private val noteAPI = NoteAPI(JSONSerializer(File("notes.json")))
+private val noteAPI = NoteAPI(CBORSerializer(File("notes.cbor")))
+
 
 
 fun main(args: Array<String>) {

--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -186,7 +186,7 @@ fun listNotesSubmenu(){
             5 -> println(noteAPI.listNotesByMonth(readNextLine("Please enter a month to search notes, example 'march': ")))
             6 -> println(noteAPI.listNotesByYear(readNextInt("Please enter a year to search notes, example '2023': ")))
             7 -> listNotesByDate()
-            0 -> mainMenu()
+            0 -> runMenu()
             else -> println("Invalid option entered: ${option}")
         }
     } while(true)

--- a/src/main/kotlin/models/Note.kt
+++ b/src/main/kotlin/models/Note.kt
@@ -1,5 +1,8 @@
 package models
 
+import kotlinx.serialization.Serializable
+
+@Serializable
 data class Note(var noteTitle: String,
                 var notePriority: Int,
                 var noteCategory: String,

--- a/src/main/kotlin/persistence/CBORSerializer.kt
+++ b/src/main/kotlin/persistence/CBORSerializer.kt
@@ -1,0 +1,33 @@
+package persistence
+
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.cbor.*
+import kotlinx.serialization.decodeFromByteArray
+import kotlinx.serialization.encodeToByteArray
+import models.Note
+import java.io.File
+import java.io.FileInputStream
+import java.io.FileOutputStream
+
+class CBORSerializer(private val file: File) : Serializer{
+    @OptIn(ExperimentalSerializationApi::class)
+    @Throws(Exception::class)
+    override fun write(obj: Any?) {
+        val byteArray = Cbor.encodeToByteArray(obj as ArrayList<Note>)
+        val file = File("notes.cbor")
+        val outputStream = FileOutputStream(file)
+        outputStream.write(byteArray)
+        outputStream.close()
+    }
+
+    @OptIn(ExperimentalSerializationApi::class)
+    @Throws(Exception::class)
+    override fun read(): ArrayList<Note> {
+        val fileToLoad = File("notes.cbor")
+        val inputStream = FileInputStream(fileToLoad)
+        val byteArray = inputStream.readBytes()
+        inputStream.close()
+        return Cbor.decodeFromByteArray(byteArray)
+    }
+
+}

--- a/src/test/kotlin/controllers/NoteAPITest.kt
+++ b/src/test/kotlin/controllers/NoteAPITest.kt
@@ -344,6 +344,47 @@ class NoteAPITest {
             assertEquals(storingNotes.findNote(2), loadedNotes.findNote(2))
         }
 
+        /*
+        CBOR FORMAT TESTS
+         */
+
+        @Test
+        fun `saving and loading an empty collection in CBOR doesn't crash app`() {
+            // Saving an empty notes.CBOR file.
+            val storingNotes = NoteAPI(CBORSerializer(File("notes.cbor")))
+            storingNotes.store()
+
+            //Loading the empty notes.cbor file into a new object
+            val loadedNotes = NoteAPI(CBORSerializer(File("notes.cbor")))
+            loadedNotes.load()
+
+            //Comparing the source of the notes (storingNotes) with the CBOR loaded notes (loadedNotes)
+            assertEquals(0, storingNotes.numberOfNotes())
+            assertEquals(0, loadedNotes.numberOfNotes())
+            assertEquals(storingNotes.numberOfNotes(), loadedNotes.numberOfNotes())
+        }
+
+        @Test
+        fun `saving and loading an loaded collection in CBOR doesn't loose data`() {
+            // Storing 3 notes to the notes.CBOR file.
+            val storingNotes = NoteAPI(CBORSerializer(File("notes.cbor")))
+            storingNotes.add(testApp!!)
+            storingNotes.add(swim!!)
+            storingNotes.add(summerHoliday!!)
+            storingNotes.store()
+
+            //Loading notes.xml into a different collection
+            val loadedNotes = NoteAPI(CBORSerializer(File("notes.cbor")))
+            loadedNotes.load()
+
+            //Comparing the source of the notes (storingNotes) with the XML loaded notes (loadedNotes)
+            assertEquals(3, storingNotes.numberOfNotes())
+            assertEquals(3, loadedNotes.numberOfNotes())
+            assertEquals(storingNotes.numberOfNotes(), loadedNotes.numberOfNotes())
+            assertEquals(storingNotes.findNote(0), loadedNotes.findNote(0))
+            assertEquals(storingNotes.findNote(1), loadedNotes.findNote(1))
+            assertEquals(storingNotes.findNote(2), loadedNotes.findNote(2))
+        }
     }
 
     @Nested

--- a/src/test/kotlin/controllers/NoteAPITest.kt
+++ b/src/test/kotlin/controllers/NoteAPITest.kt
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import persistence.CBORSerializer
 import persistence.JSONSerializer
 import persistence.XMLSerializer
 import java.io.File
@@ -261,6 +262,9 @@ class NoteAPITest {
     @Nested
     inner class PersistenceTests {
 
+        /*
+        XML FORMAT TESTS
+         */
         @Test
         fun `saving and loading an empty collection in XML doesn't crash app`() {
             // Saving an empty notes.XML file.
@@ -299,6 +303,9 @@ class NoteAPITest {
             assertEquals(storingNotes.findNote(2), loadedNotes.findNote(2))
         }
 
+        /*
+        JSON FORMAT TESTS
+         */
         @Test
         fun `saving and loading an empty collection in JSON doesn't crash app`() {
             // Saving an empty notes.json file.
@@ -336,6 +343,7 @@ class NoteAPITest {
             assertEquals(storingNotes.findNote(1), loadedNotes.findNote(1))
             assertEquals(storingNotes.findNote(2), loadedNotes.findNote(2))
         }
+
     }
 
     @Nested


### PR DESCRIPTION
Pull request linked to Issue #28 

Implemented functionality for storing data in CBOR format to external file "notes.cbor"
All JUnit tests passing.

_Also fixed minor bug with the sub-menu for listing notes, when trying to exit to the main menu, the main menu doesn't take user input and directs it back to the sub-menu even after trying to exit, (infinite loop)._

When this pull request is merged: Closes #28 